### PR TITLE
Add set_threadgroup_memory_length to CommandEncoder

### DIFF
--- a/mlx/backend/metal/device.h
+++ b/mlx/backend/metal/device.h
@@ -95,6 +95,10 @@ struct CommandEncoder {
     return enc_->setBytes(&v, sizeof(T), idx);
   }
 
+  void set_threadgroup_memory_length(size_t length, NS::UInteger index) {
+    enc_->setThreadgroupMemoryLength(length, index);
+  }
+
   ConcurrentContext start_concurrent() {
     return ConcurrentContext(*this);
   }


### PR DESCRIPTION
## Summary
- Adds a `set_threadgroup_memory_length` method to the `CommandEncoder` class in Metal backend
- Provides direct access to Metal's setThreadgroupMemoryLength functionality
- Enables better control of threadgroup memory for custom Metal compute kernels

## Test plan
- The method is a simple wrapper around an existing Metal API
- This is a straightforward API addition that doesn't modify existing functionality